### PR TITLE
action.php feature

### DIFF
--- a/action.php
+++ b/action.php
@@ -26,7 +26,7 @@ class action_plugin_codebuttonmod1 extends DokuWiki_Action_Plugin {
             'type' => 'format',
             'title' => $this->getLang('insertcode'),
             'icon' => '../../plugins/codebuttonmod1/image/code.png',
-            'open' => '<code | download>\n',
+            'open' => '<code | download.txt>\n',
             'close' => '\n</code>',
         );
     }


### PR DESCRIPTION
This change would allow "download" to be downloaded with a file extension suitable to open via file association by users preferred text editor. e.g: notepad.exe on a windows client machine. 

Cheers! 